### PR TITLE
WebSocketProvider 및 authCheck 기능 개선

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,8 +9,8 @@ import { WebSocketProvider } from "./provider/WebSocketProvider";
 function App() {
   return (
     <CommonLayout>
-      <WebSocketProvider>
-        <BrowserRouter>
+      <BrowserRouter>
+        <WebSocketProvider>
           <Routes>
             <Route path="/signin" element={<SigninPage />} />
             <Route path="/signup" element={<SignupPage />} />
@@ -19,8 +19,8 @@ function App() {
               {/* my-room 추가 예정 */}
             </Route>
           </Routes>
-        </BrowserRouter>
-      </WebSocketProvider>
+        </WebSocketProvider>
+      </BrowserRouter>
     </CommonLayout>
   );
 }

--- a/src/lib/authCheck.ts
+++ b/src/lib/authCheck.ts
@@ -1,4 +1,5 @@
 import { API_ENDPOINT } from "@/constants";
+import useTrackSubwayStore from "@/stores/trackSubway";
 
 type authCheckFuncProps = (result: {
   email: string;
@@ -41,6 +42,13 @@ const authCheckFunc = async (setUserInfo: authCheckFuncProps) => {
         id: userInfo.payload.user.id,
         nickname: userInfo.payload.user.nickname,
       });
+      if (userInfo.payload?.subwayNumber) {
+        useTrackSubwayStore
+          .getState()
+          .setSubwayNumber(userInfo.payload.subwayNumber);
+      } else {
+        useTrackSubwayStore.getState().resetSubwayNumber();
+      }
     }
 
     return userInfo.result === "success";


### PR DESCRIPTION
## WebSocketProvider 및 authCheck 기능 개선 

### ⚠️ 문제점

사용자의 검색어, 추적을 시작한 지하철 정보를 zustand 스토어로 관리하고 있음.
앱에 새로고침이 발생할 경우 모든 상태가 초기화되기 때문에 추적중인 지하철임에도 불구하고
UI 상 추적중인 상태로 표시되지 않음. 따라서 같은 지하철을 중복으로 추적 시도하는 문제 발생
UX 를 위해서 사용자가 검색한 내용을 새로고침이 발생하더라도 이어서 보여줄 수 있어야 함. 
그러나 현재는 새로고침이 발생될 경우 검색 결과가 초기화되고 다시 검색을 해야 하는 문제가 있음.

### ❌ 오류 

서비스는 로그인한 사용자만 사용할 수 있음. 그러나 Web Socket 연결이 모든 페이지에서 시도되고 있음.
즉, 로그인한 사용자가 메인 페이지(/)에 접속했을 때 Web Socket 연결이 발생해야 함. 그러나 현재는
signin/signup 페이지에서도 웹 소켓 연결 발생하는 오류
 
### ✅ WebSocketProvider에서 사용자 정보에 따라 WebSocket 연결 로직 수정

useLocation을 사용해서 메인페이지("/")일 때만 웹 소켓을 연결하도록 수정.
웹 소켓이 연결되었을 때, zustand에서 userId를 가져와서 
메시지 타입 init으로 userId를 보냄.

### ✅ authCheck 함수에서 지하철 번호 설정 및 초기화 로직 추가

서버에서는 /user/me 라우트로 유저 정보를 요청할 때, 구독중인 지하철이 존재한다면 
지하철 번호를 응답. authCheck에서는 구독중인 지하철 정보가 있을 때 지하철 번호를 받아서 
setSubwayNumber로 상태 초기화.

### ✅ App.tsx에서 WebSocketProvider와 BrowserRouter의 위치 변경

WebSocketProvider가 BrowserRouter 바깥에 있는 구조이기 때문에 Router Context에 접근할 수 없었음
따라서 순서 변경