### PR TITLE
#47 arrive state

### DIFF
--- a/src/components/Subway.tsx
+++ b/src/components/Subway.tsx
@@ -122,6 +122,11 @@ const Subway = ({ subwayInfo }: SubwayProps) => {
                     : `bg-${subwayInfo.subwayId} hover:bg-${subwayInfo.subwayId}/90 text-white`
                 }
               `}
+              disabled={
+                subwayInfo.arvlCd === "0" ||
+                subwayInfo.arvlCd === "1" ||
+                subwayInfo.arvlCd === "2"
+              }
             >
               {isSubwaySelected ? (
                 <>

--- a/src/lib/authCheck.ts
+++ b/src/lib/authCheck.ts
@@ -1,5 +1,4 @@
 import { API_ENDPOINT } from "@/constants";
-import useTrackSubwayStore from "@/stores/trackSubway";
 
 type authCheckFuncProps = (result: {
   email: string;
@@ -42,13 +41,6 @@ const authCheckFunc = async (setUserInfo: authCheckFuncProps) => {
         id: userInfo.payload.user.id,
         nickname: userInfo.payload.user.nickname,
       });
-      if (userInfo.payload?.subwayNumber) {
-        useTrackSubwayStore
-          .getState()
-          .setSubwayNumber(userInfo.payload.subwayNumber);
-      } else {
-        useTrackSubwayStore.getState().resetSubwayNumber();
-      }
     }
 
     return userInfo.result === "success";

--- a/src/provider/WebSocketProvider.tsx
+++ b/src/provider/WebSocketProvider.tsx
@@ -1,6 +1,7 @@
 import { WS_ENDPOINT } from "@/constants";
 import { toast } from "@/hooks/use-toast";
 import useSearchResultStore from "@/stores/searchResult";
+import useTrackSubwayStore from "@/stores/trackSubway";
 import useUserInfoStore from "@/stores/userInfo";
 import React, {
   MutableRefObject,
@@ -67,6 +68,19 @@ export const WebSocketProvider = ({
           title: "추적 중단",
           description: "선택하신 지하철의 실시간 위치 추적을 중단했습니다.",
         });
+      } else if (type === "tracking_completed") {
+        toast({
+          title: "추적 완료",
+          description: "선택하신 지하철의 실시간 위치 추적을 완료했습니다.",
+        });
+        useTrackSubwayStore.getState().resetSubwayNumber();
+      } else if (type === "tracking_status") {
+        toast({
+          title: "추적 상태 업데이트",
+          description:
+            "선택하신 지하철의 실시간 위치 추적 상태를 업데이트했습니다.",
+        });
+        useTrackSubwayStore.getState().setSubwayNumber(data.subwayNumber);
       }
     };
 


### PR DESCRIPTION
### ✅ 실시간 지하철 정보, 추적중인 지하철 정보

실시간 지하철 정보는 Web Socket으로 서버에서 받아오고

사용자가 특정 지하철을 추적할 경우 지하철에 대한 알림은 Web Push Notification으로 전달된다.

실시간 지하철 정보와, 추적중인 지하철 정보를 수신받는 방식이 다른 상황.

"서울"역을 검색하다 다른 역을 검색하면, 서울 역에 대한 실시간 정보는 더 이상 수신되지 않는다.

### ❌  추적중인 지하철 상태 관리

사용자가 추적을 시작하면 zustand 스토어로 추적하려는 지하철의 번호를 저장한다.

추적중인 지하철이 완료되었을 때, 서비스워커에서 이벤트를 수신하고 있지만 스토어를 초기화하는 로직이 없음.

따라서 도착한 지하철이지만 추적 상태로 남아 있고 추적 중단 버튼이 활성화된다.

백엔드에서는 완료된 지하철을 데이터베이스에서 삭제하기 때문에 추적 중단 버튼을 클릭할 경우 에러가 발생함.

### ✅ 웹 소켓 조건식 추가

백엔드 서버에서 tracking_completed, tracking_status 메시지를 전달한다.

이로 인해 기존에 user 정보를 요청할 때 받아오던 사용자의 추적중인 지하철 정보를 웹 소켓으로 전달 받는다.

따라서 이전에 authCheck에서 추적중인 지하철 정보를 받아 전역 상태로 등록하던 로직 삭제

### ✅ 추적 등록 조건 추가

기존에는 도착한 지하철도 추적이 가능했지만

실시간으로 전달 받은 지하철의 상태가 0:진입, 1:도착, 2:출발 일 경우 추적 등록을 할 수 없도록

버튼의 disabled 조건 추가

